### PR TITLE
fix(bedrock): skip empty text content blocks in Converse API messages

### DIFF
--- a/src/providers/bedrock.rs
+++ b/src/providers/bedrock.rs
@@ -655,7 +655,7 @@ impl BedrockProvider {
                             role: "assistant".to_string(),
                             content: blocks,
                         });
-                    } else {
+                    } else if !msg.content.trim().is_empty() {
                         converse_messages.push(ConverseMessage {
                             role: "assistant".to_string(),
                             content: vec![ContentBlock::Text(TextBlock {
@@ -663,6 +663,8 @@ impl BedrockProvider {
                             })],
                         });
                     }
+                    // Skip assistant messages with empty content — Bedrock rejects
+                    // ContentBlock objects where the text field is blank.
                 }
                 "tool" => {
                     let tool_result_msg = Self::parse_tool_result_message(&msg.content)
@@ -846,7 +848,7 @@ impl BedrockProvider {
             }));
         }
 
-        if blocks.is_empty() {
+        if blocks.is_empty() && !content.trim().is_empty() {
             blocks.push(ContentBlock::Text(TextBlock {
                 text: content.to_string(),
             }));


### PR DESCRIPTION
## Summary
- Bedrock's Converse API rejects ContentBlock objects where the text field is blank (`400 Bad Request: "The text field in the ContentBlock object at messages.N.content.0 is blank"`)
- This happens when the LLM returns a tool call without accompanying text — ZeroClaw stores the assistant turn with empty content, then sends `text: ""` to Bedrock on the next turn
- Skip empty/whitespace-only assistant messages and user content blocks instead of sending blank text fields
- Mirrors the fix in `058ce1d1` (anthropic provider) for the bedrock provider

## Test plan
- [ ] Deploy to dev agent and verify Telegram tool-call conversations no longer produce "Error: All providers/models failed" with 400 Bad Request